### PR TITLE
Make lpf-approve honor the PAGER environment variable

### DIFF
--- a/scripts/lpf-approve
+++ b/scripts/lpf-approve
@@ -44,7 +44,7 @@ function cli_approve()
 # User approves EULA, no GUI.
 {
     local license=$1
-    more $license
+    ${PAGER:-more} $license
     echo -n "Do you accept these license terms [n] ? "
     read reply
     [ -z "$reply" ] && reply='No'


### PR DESCRIPTION
more doesn’t suite everybody’s needs, and it lacks some features,
like you can’t scroll backwards.  There are fancier pagers, like
less, which might be preferred by some users.

This commit honors the standard `PAGER` environment variable and
uses that program if set.  If not set, it defaults to the
original `more` command.